### PR TITLE
Adds moduleResolution to the example tsconfig

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -27,6 +27,7 @@ Basic recommended configuration:
   "compilerOptions": {
     "target": "esnext",
     "lib": ["esnext"],
+    "moduleResolution": "node",
     "types": [],
     "strict": true
   },


### PR DESCRIPTION
This is to make sure that when you add `lua-types` later, it won't break mysteriously