### PR TITLE
better docs

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -24,10 +24,12 @@ Basic recommended configuration:
 
 ```json title=tsconfig.json
 {
+  // For reference, all TypeScript compiler options can be found at:
+  // https://www.typescriptlang.org/docs/handbook/compiler-options.html
   "compilerOptions": {
-    "target": "esnext",
-    "lib": ["esnext"],
-    "moduleResolution": "node",
+    "target": "ESNext",
+    "lib": ["ESNext"],
+    "moduleResolution": "Node",
     "types": [],
     "strict": true
   },

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -31,10 +31,10 @@ Basic recommended configuration:
     "lib": ["ESNext"],
     "moduleResolution": "Node",
     "types": [],
-    "strict": true
+    "strict": true,
   },
   "tstl": {
-    "luaTarget": "JIT"
+    "luaTarget": "JIT",
   }
 }
 ```


### PR DESCRIPTION
1) the entries for "target" and "lib" do not match the stylization of the official typescript documentation 
2) I added a link to the official docs for handy reference
3) I added trailing commas to tsconfig.json, which is considered best practice in the typescript ecosystem