### PR TITLE
Add some more information about modules

### DIFF
--- a/docs/external-lua-code.md
+++ b/docs/external-lua-code.md
@@ -24,3 +24,11 @@ import { myFunction } from "./somelua";
 
 myFunction();
 ```
+
+## Using NPM packages
+
+To use a Lua package, install it via npm and use it as you would for any regular npm package in TypeScript. If the package does not include its own `.d.ts` declaration files, you can create your own by adding a `<package name>.d.ts` [declaration file](./advanced/writing-declarations.md) to your source files.
+
+:::note
+Including TS or JS files from npm packages is currently NOT supported.
+:::

--- a/docs/external-lua-code.md
+++ b/docs/external-lua-code.md
@@ -6,7 +6,9 @@ As of `0.40.0`, tstl supports module resolution for libraries, which means you c
 
 ## Adding Lua files to your project sources
 
-You can simply add a Lua file as part of your project sources if you add [a declaration file](./advanced/writing-declarations.md) with the same name. You can then simply import the Lua code in your TypeScript. Your project should look like:
+You can simply add a Lua file as part of your project sources if you add [a declaration file](./advanced/writing-declarations.md) with the same name. You can then simply import the Lua code in your TypeScript.
+
+Your project should look like:
 
 ```
 main.ts
@@ -15,73 +17,10 @@ somelua.d.ts
 tsconfig.json
 ```
 
-## Using NPM packages
+And you can use it like so:
 
-To use a Lua package, install it via npm and use it as you would for any regular npm package in TypeScript. If the package does not include its own `.d.ts` declaration files, you can create your own by adding a `<package name>.d.ts` [declaration file](./advanced/writing-declarations.md) to your source files.
+```ts title=main.ts
+import { myFunction } from "./somelua";
 
-:::note
-Including TS or JS files from npm packages is currently NOT supported.
-:::
-
-## Creating Lua NPM packages
-
-If you want to distribute your tstl created Lua as a library, you will need to enable the library build mode in `tsconfig.json`, and enable the output of declaration files:
-
-```json title=json.config
-{
-    "compilerOptions": {
-        ...
-        "outDir": "dist", // Output package contents to dist directory
-        "declaration": true
-    },
-    "tstl": {
-        ...
-        "buildMode": "library"
-    }
-}
+myFunction();
 ```
-
-Then add or update your `package.json` so it contains the following information:
-
-```json title=package.json
-{
-  "name": "example-tstl-lua-package",
-  "version": "1.0.0",
-  "description": "A package created with TypeScriptToLua",
-  "scripts": {
-    "prepublish": "tstl" // Make sure latest lua is built before publishing
-  },
-  // Only include dist files
-  "files": ["dist/**/*.lua", "dist/**/*.d.ts"]
-}
-```
-
-With these two files you are now ready to publish your npm package with `npm publish`!
-
-:::warning
-Currently, projects using `"buildMode": "library"` tsconfig setting must also have the `luaBundle` setting turned off. (However, you can still _consume_ unbundled libraries in projects that use `luaBundle` without any problems.)
-:::
-
-## Example projects
-
-For example projects using external Lua, you can look at the projects used in the TypeScriptToLua tests:
-
-### [A project using Lua from node_modules packages](https://github.com/TypeScriptToLua/TypeScriptToLua/tree/master/test/transpile/module-resolution/project-with-node-modules)
-
-A project using dependencies from its [node_modules directory](https://github.com/TypeScriptToLua/TypeScriptToLua/tree/master/test/transpile/module-resolution/project-with-node-modules/node_modules) with Lua code. These example dependencies include:
-
-- `lua-global-with-decls`: Lua code + TypeScript declarations defining global functions.
-- `lua-global-without-decls`: Lua code defining global functions.
-  - Declaration file is added manually in [lua-global-without-decls.d.ts in the project sources](https://github.com/TypeScriptToLua/TypeScriptToLua/tree/master/test/transpile/module-resolution/project-with-node-modules).
-- `lua-module-with-decls`: Lua code + TypeScript declarations for 'module' files, i.e Lua files that return a table of exported functions.
-- `lua-module-with-decls`: Lua code for 'module' files, i.e Lua files that return a table of exported functions.
-  - Declaration files are added manually in [lua-module-without-decls.d.ts in the project sources](https://github.com/TypeScriptToLua/TypeScriptToLua/tree/master/test/transpile/module-resolution/project-with-node-modules).
-
-### [A project with Lua sources](https://github.com/TypeScriptToLua/TypeScriptToLua/tree/master/test/transpile/module-resolution/project-with-lua-sources)
-
-This project includes Lua files as part of the project's source files. To use the Lua from the files you have to provide declaration files with a matching name and location for each file. For examples `some_dir/library.lua` & `some_dir/library.d.ts`. The declaration files contain the TypeScript declarations of the corresponding Lua file. Both Lua and .d.ts files should be checked into your repository!
-
-This project contains two Lua source files:
-
-- `luafile.lua`: Some Lua right next to the .ts files using it.
-- `lua_sources/otherluaFile.lua`: Lua in a separate `lua_sources` directory, in case you want to group all your Lua files into one directory.

--- a/docs/publishing-modules.md
+++ b/docs/publishing-modules.md
@@ -15,12 +15,12 @@ Your `tsconfig.json` file must at least specify the following...
 
 ```json title=tsconfig.json
 {
-    "compilerOptions": {
-      "declaration": true
-    },
-    "tstl": {
-        "buildMode": "library"
-    }
+  "compilerOptions": {
+    "declaration": true
+  },
+  "tstl": {
+    "buildMode": "library"
+  }
 }
 ```
 
@@ -33,7 +33,7 @@ And your `package.json` file should specify the `types` property. You should als
 }
 ```
 
-These must be __relative__ paths within your module __without__ the file's extension.
+These must be **relative** paths within your module **without** the file's extension.
 
 > These are set to `"index"` by default so if you _really_ don't want to specify these you can keep an `index.d.ts` and `index.lua` file at the top level of your package.
 
@@ -46,8 +46,8 @@ This is useful if you don't want to publish your source code.
 ```json title=package.json
 {
   "files": [
-    "dist/**/*.lua",  // publish all Lua files in /dist/
-    "dist/**/*.d.ts"  // publish all declaration files in /dist/
+    "dist/**/*.lua", // publish all Lua files in /dist/
+    "dist/**/*.d.ts" // publish all declaration files in /dist/
   ]
 }
 ```

--- a/docs/publishing-modules.md
+++ b/docs/publishing-modules.md
@@ -7,7 +7,7 @@ As of `0.40.0`, tstl supports module resolution for libraries, which means you c
 - You cannot import `.ts` and `.tsx` source files
 - You must use `"buildMode": "library"`
 - It is recommended you use `"declaration": true`
-- You cannot use `"luaBundle"`
+- You cannot use `"luaBundle"` in packages intended to be included as dependency in another project
 
 ## Project Configuration
 

--- a/docs/publishing-modules.md
+++ b/docs/publishing-modules.md
@@ -1,0 +1,105 @@
+---
+title: Publishing Modules
+---
+
+As of `0.40.0`, tstl supports module resolution for libraries, which means you can _use_ and _create_ npm packages containing `.lua` files. You can also include Lua source files directly into your source code.
+
+- You cannot import `.ts` and `.tsx` source files
+- You must use `"buildMode": "library"`
+- It is recommended you use `"declaration": true`
+- You cannot use `"luaBundle"`
+
+## Project Configuration
+
+Your `tsconfig.json` file must at least specify the following...
+
+```json title=tsconfig.json
+{
+    "compilerOptions": {
+      "declaration": true
+    },
+    "tstl": {
+        "buildMode": "library"
+    }
+}
+```
+
+And your `package.json` file should specify the `types` property. You should also specify the `main` property if your module contains runnable Lua code.
+
+```json title=package.json
+{
+  "main": "./dist/index", // points to ./dist/index.lua
+  "types": "./dist/index" // points to ./dist/index.d.ts
+}
+```
+
+These must be __relative__ paths within your module __without__ the file's extension.
+
+> These are set to `"index"` by default so if you _really_ don't want to specify these you can keep an `index.d.ts` and `index.lua` file at the top level of your package.
+
+## Publishing
+
+Within your `package.json` you can specify the `files` field to mark what files to publish.
+
+This is useful if you don't want to publish your source code.
+
+```json title=package.json
+{
+  "files": [
+    "dist/**/*.lua",  // publish all Lua files in /dist/
+    "dist/**/*.d.ts"  // publish all declaration files in /dist/
+  ]
+}
+```
+
+You can use `npm publish --dry-run` to see what files would be published without publishing your package.
+
+- Some files will always be published e.g. `package.json`, `README.md`.
+- Modules specified in `"devDependencies"` will not be available to the module at runtime.
+- The `tsconfig.json` file does nothing for users of your module.
+
+And when you're happy, your `package.json` has a `name`, `version`, `description`, and you are logged into NPM on your machine... you can run `npm publish` to publish your module.
+
+## Using the Module
+
+Assuming the module is available on NPM, users of your module can download it like so.
+
+```bash
+npm install <package-name>
+# OR
+yarn add <package-name>
+```
+
+Now they can start using it.
+
+```ts title=example.ts
+import { func } from "<package-name>";
+
+func();
+```
+
+TypeScriptToLua will handle the module resolution from here.
+
+## Example projects
+
+For example projects using external Lua, you can look at the projects used in the TypeScriptToLua tests:
+
+### [A project using Lua from node_modules packages](https://github.com/TypeScriptToLua/TypeScriptToLua/tree/master/test/transpile/module-resolution/project-with-node-modules)
+
+A project using dependencies from its [node_modules directory](https://github.com/TypeScriptToLua/TypeScriptToLua/tree/master/test/transpile/module-resolution/project-with-node-modules/node_modules) with Lua code. These example dependencies include:
+
+- `lua-global-with-decls`: Lua code + TypeScript declarations defining global functions.
+- `lua-global-without-decls`: Lua code defining global functions.
+  - Declaration file is added manually in [lua-global-without-decls.d.ts in the project sources](https://github.com/TypeScriptToLua/TypeScriptToLua/tree/master/test/transpile/module-resolution/project-with-node-modules).
+- `lua-module-with-decls`: Lua code + TypeScript declarations for 'module' files, i.e Lua files that return a table of exported functions.
+- `lua-module-with-decls`: Lua code for 'module' files, i.e Lua files that return a table of exported functions.
+  - Declaration files are added manually in [lua-module-without-decls.d.ts in the project sources](https://github.com/TypeScriptToLua/TypeScriptToLua/tree/master/test/transpile/module-resolution/project-with-node-modules).
+
+### [A project with Lua sources](https://github.com/TypeScriptToLua/TypeScriptToLua/tree/master/test/transpile/module-resolution/project-with-lua-sources)
+
+This project includes Lua files as part of the project's source files. To use the Lua from the files you have to provide declaration files with a matching name and location for each file. For examples `some_dir/library.lua` & `some_dir/library.d.ts`. The declaration files contain the TypeScript declarations of the corresponding Lua file. Both Lua and .d.ts files should be checked into your repository!
+
+This project contains two Lua source files:
+
+- `luafile.lua`: Some Lua right next to the .ts files using it.
+- `lua_sources/otherluaFile.lua`: Lua in a separate `lua_sources` directory, in case you want to group all your Lua files into one directory.

--- a/sidebars.json
+++ b/sidebars.json
@@ -5,6 +5,7 @@
         "caveats",
         "the-self-parameter",
         "external-lua-code",
+        "publishing-modules",
         "editor-support",
         "advanced/writing-declarations",
         "advanced/compiler-annotations",


### PR DESCRIPTION
Resolves #56

Broke down `external-lua-code` into two pages, one for importing Lua code sitting in a project and the other for publishing modules containing Lua code