### PR TITLE
fix for code coloring

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -108,10 +108,10 @@ export default function Home() {
                 <section className="padding-vert--md container">
                     <div className="row">
                         <div className={`col col--6 ${styles.example}`}>
-                            <CodeBlock className="typescript">{exampleSource}</CodeBlock>
+                            <CodeBlock language="typescript">{exampleSource}</CodeBlock>
                         </div>
                         <div className={`col col--6 ${styles.example}`}>
-                            <CodeBlock className="lua">{exampleOutput}</CodeBlock>
+                            <CodeBlock language="lua">{exampleOutput}</CodeBlock>
                         </div>
                     </div>
                 </section>


### PR DESCRIPTION
The current method of code coloring will break when you upgrade to `docusaurus v2.0.0-beta.8` or later.
Only merge this PR when you update the deps at the same time.