### PR TITLE
Update getting-started.md with Tabletop Simulator

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -118,8 +118,8 @@ Additionally, type declarations exist for some games:
 - [Factorio](https://github.com/GlassBricks/typed-factorio)
 - [Garry's Mod](https://github.com/lolleko/gmod-typescript)
 - [Retro Gadget](https://github.com/DarkMio/retro-gadgets-typedefs) ([template](https://github.com/DarkMio/retro-gadgets-template))
+- [Tabletop Simulator](https://github.com/stevenlafl/tts-typescript)
 - [World of Warcraft](https://github.com/wartoshika/wow-declarations)
 - [World of Warcraft Classic](https://github.com/wartoshika/wow-classic-declarations)
-- [Tabletop Simulator](https://github.com/stevenlafl/tts-typescript)
 
 (If you have created type declarations for a new game, you can click on the "Edit this page" link below to add it to the list.)

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -120,5 +120,6 @@ Additionally, type declarations exist for some games:
 - [Retro Gadget](https://github.com/DarkMio/retro-gadgets-typedefs) ([template](https://github.com/DarkMio/retro-gadgets-template))
 - [World of Warcraft](https://github.com/wartoshika/wow-declarations)
 - [World of Warcraft Classic](https://github.com/wartoshika/wow-classic-declarations)
+- [Tabletop Simulator](https://github.com/stevenlafl/tts-typescript)
 
 (If you have created type declarations for a new game, you can click on the "Edit this page" link below to add it to the list.)


### PR DESCRIPTION
Added Tabletop Simulator type definitions to the list of declarations in the Getting Started section of the docs.