### PR TITLE
Added World of Warcraft WOTLK declarations

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -121,6 +121,7 @@ Additionally, type declarations exist for some games:
 - [Retro Gadget](https://github.com/DarkMio/retro-gadgets-typedefs) ([template](https://github.com/DarkMio/retro-gadgets-template))
 - [Tabletop Simulator](https://github.com/stevenlafl/tts-typescript)
 - [World of Warcraft](https://github.com/wartoshika/wow-declarations)
+- [World of Warcraft WOTLK](https://github.com/araxiaonline/wow-wotlk-declarations) ([eluna module builder](https://github.com/araxiaonline/wow-eluna-ts-module))
 - [World of Warcraft Classic](https://github.com/wartoshika/wow-classic-declarations)
 
 (If you have created type declarations for a new game, you can click on the "Edit this page" link below to add it to the list.)


### PR DESCRIPTION
This is a small tweak to the unofficial declarations page that is specifically for WoW Wotlk.  

The new version address many of the issues with tuple returns that have changed in the original declarations and adds some missing WoW API methods. 

I additionally, added the dev tool that uses TypeScriptToLua as it's transpile engine for developing eluna modules. 
